### PR TITLE
feat: one-liner install registers commands/agents + auto-bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
 # opencode-palantir
 
-OpenCode plugin that provides **Palantir Foundry documentation** to AI agents via a local Parquet
-database.
+[![npm](https://img.shields.io/npm/v/@openontology/opencode-palantir?logo=npm&label=npm)](https://www.npmjs.com/package/@openontology/opencode-palantir)
+[![downloads](https://img.shields.io/npm/dm/@openontology/opencode-palantir?logo=npm&label=downloads)](https://www.npmjs.com/package/@openontology/opencode-palantir)
+![CI](https://github.com/anand-testcompare/opencode-palantir/actions/workflows/pr.yml/badge.svg)
+![bun](https://img.shields.io/badge/bun-1.3.2-000000?logo=bun&logoColor=white)
+![@opencode-ai/plugin](https://img.shields.io/github/package-json/dependency-version/anand-testcompare/opencode-palantir/dev/%40opencode-ai%2Fplugin?label=opencode%20plugin%20api)
+![palantir-mcp](https://img.shields.io/npm/v/palantir-mcp?logo=npm&label=palantir-mcp)
+![hyparquet](https://img.shields.io/github/package-json/dependency-version/anand-testcompare/opencode-palantir/hyparquet?label=hyparquet)
 
-## Features
+OpenCode plugin that provides:
 
-- Fetches all ~3,600 pages from Palantir's public documentation
-- Stores in a local Parquet file for fast offline access (~17MB)
-- Exposes `get_doc_page` and `list_all_docs` tools for AI agents
+- Palantir public documentation tools backed by a local Parquet database
+- Foundry MCP bootstrapping helpers (commands, agents, and optional auto-bootstrap)
 
-## Quick start (OpenCode users)
+NPM package: https://www.npmjs.com/package/@openontology/opencode-palantir
 
-### 1) Enable the plugin in `opencode.json` / `opencode.jsonc`
+## Supported OS
 
-Add the plugin to your OpenCode config:
+- Supported: macOS, Linux
+- Windows: not supported (WSL2 might work, but we don’t debug Windows-specific issues)
+
+## Install (OpenCode)
+
+Add the plugin in your OpenCode config (`opencode.jsonc`):
 
 ```jsonc
 {
@@ -30,7 +39,23 @@ After enabling the plugin, OpenCode will automatically register:
 - Commands: `/refresh-docs`, `/setup-palantir-mcp`, `/rescan-palantir-mcp-tools`
 - Agents: `foundry-librarian`, `foundry`
 
-### 2) (Optional) Install per-project
+### Versions: how to get the latest
+
+Prefer **pinned** or **semver range** installs (like `@^0.1.4`), and update intentionally.
+
+Avoid using `@latest` in config:
+
+- it can make startup slower (npm resolution/install on startup)
+- it makes behavior less deterministic
+- depending on caching, you may not get the upgrade behavior you expect
+
+To find the newest version and changelog:
+
+- NPM versions: https://www.npmjs.com/package/@openontology/opencode-palantir
+- GitHub releases: https://github.com/anand-testcompare/opencode-palantir/releases
+- Repo changelog: `CHANGELOG.md`
+
+### (Optional) Install per-project
 
 In your project repo, add the plugin as a dependency inside `.opencode/` (keeps plugin deps separate
 from your app deps):
@@ -63,77 +88,147 @@ EOF
 
 OpenCode automatically loads `.js`/`.ts` files from `.opencode/plugins/` at startup.
 
-> If your OpenCode setup uses an `opencode.json` / `opencode.jsonc` that restricts plugin loading,
-> make sure `.opencode/plugins/` (or the specific plugin file) is included.
+## Environment variables (Foundry MCP)
 
-### 3) Get `docs.parquet`
+This plugin never writes secrets to disk. In `opencode.jsonc`, the token is always referenced as
+`{env:FOUNDRY_TOKEN}`.
 
-This package does **not** ship with docs bundled. You have two options:
+### Variables
 
-#### Option A (recommended): fetch inside OpenCode
+- `FOUNDRY_URL`
+  - Foundry base URL (used for auto-bootstrap and can be used as a default for `/setup-palantir-mcp`)
+  - Example: `https://YOUR-STACK.usw-3.palantirfoundry.com`
+- `FOUNDRY_TOKEN`
+  - Foundry token used by `palantir-mcp` for tool discovery
+  - Must be exported (not just set in a shell)
+
+### Recommended setup (zsh, macOS/Linux)
+
+Keep secrets in a separate file and source it from your shell init.
+
+Create `~/.config/opencode/secrets.zsh`:
+
+```zsh
+export FOUNDRY_URL='https://YOUR-STACK.palantirfoundry.com'
+export FOUNDRY_TOKEN='YOUR_TOKEN'
+```
+
+Lock it down:
+
+```bash
+chmod 600 ~/.config/opencode/secrets.zsh
+```
+
+Source it from `~/.zshrc`:
+
+```zsh
+if [ -f "$HOME/.config/opencode/secrets.zsh" ]; then
+  source "$HOME/.config/opencode/secrets.zsh"
+fi
+```
+
+If you still see “token not exported” errors, verify `echo $FOUNDRY_TOKEN` prints a value and that
+it’s `export`ed in the environment where OpenCode is launched.
+
+## Docs tools (Palantir public docs)
+
+This package does **not** ship with docs bundled. The docs DB is a local file:
+
+- `data/docs.parquet` (in your repo root)
+
+### Fetch docs
 
 In OpenCode, run:
 
 - `/refresh-docs`
 
-This downloads the docs and writes them to `data/docs.parquet` in your project root.
+This downloads the docs and writes `data/docs.parquet`.
 
-#### Option B: download a prebuilt Parquet file
+### Tools
 
-Download `data/docs.parquet` from this GitHub repo and place it at:
+- `get_doc_page`
+  - Retrieve a doc page by URL, or fuzzy match by query
+- `list_all_docs`
+  - List docs with pagination and optional query/scope filtering
 
-- `<your-project>/data/docs.parquet`
+If `data/docs.parquet` is missing, both tools will tell you to run `/refresh-docs`.
 
-## Using the tools
+## Foundry MCP helpers
 
-When installed, this plugin exposes:
-
-- **`get_doc_page`** - Retrieve a specific doc page by URL
-- **`list_all_docs`** - List all available documentation pages
-
-If `data/docs.parquet` is missing, both tools will instruct you to run `/refresh-docs`.
-
-## Foundry MCP setup helpers
-
-This plugin registers Foundry helper commands and agents automatically at startup (config-driven).
+This plugin registers Foundry commands and agents automatically at startup (config-driven).
 
 ### Auto-bootstrap (no command required)
 
-If you set both `FOUNDRY_TOKEN` and `FOUNDRY_URL` in your environment, the plugin will
-automatically and idempotently patch repo-root `opencode.jsonc` to initialize:
+If you set both `FOUNDRY_TOKEN` and `FOUNDRY_URL`, the plugin will automatically and idempotently
+patch repo-root `opencode.jsonc` to initialize:
 
 - `mcp.palantir-mcp` local server config
 - global tool deny: `tools.palantir-mcp_* = false`
-- per-agent `palantir-mcp_*` allow/deny toggles under `foundry-librarian` and `foundry`
-
-Secrets are never written: `FOUNDRY_TOKEN` is referenced as `{env:FOUNDRY_TOKEN}`.
+- per-agent allow/deny toggles under `foundry-librarian` and `foundry`
 
 ### Guided setup and maintenance
 
-You can also use the commands below to set up and maintain `palantir-mcp` with project-scoped tool
-gating and Foundry sub-agents:
-
-- **`/setup-palantir-mcp <foundry_api_url>`**
+- `/setup-palantir-mcp <foundry_api_url>`
   - Creates/patches repo-root `opencode.jsonc`
   - Adds `mcp.palantir-mcp` (if missing) as a local `npx palantir-mcp --foundry-api-url ...` server
   - Enforces global deny: `tools.palantir-mcp_* = false`
   - Creates `foundry-librarian` and `foundry` agents
-  - Dynamically discovers the current `palantir-mcp` tool list and writes explicit `true/false`
-    per-tool toggles under each Foundry agent
-- **`/rescan-palantir-mcp-tools`**
-  - Re-discovers the `palantir-mcp` tool list and adds any missing explicit toggles
+  - Discovers `palantir-mcp` tools and writes explicit `true/false` toggles under each agent
+- `/rescan-palantir-mcp-tools`
+  - Re-discovers the `palantir-mcp` tool list and adds missing explicit toggles
   - Never overwrites existing `palantir-mcp_*` toggles
 
-Auth is always env-only. The token is referenced as `{env:FOUNDRY_TOKEN}` and is never written to
-disk.
+### About palantir-mcp versions (important)
 
-## Setup (this repo)
+The generated MCP server uses `npx -y palantir-mcp ...` by default.
 
-```bash
-bun install
+Notes:
+
+- First run can be slow (npx may need to download/install).
+- `@latest` / unpinned installs are less deterministic.
+
+Recommendation: once you’re set up, pin the version in `opencode.jsonc`:
+
+```jsonc
+{
+  "mcp": {
+    "palantir-mcp": {
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "palantir-mcp@<version>",
+        "--foundry-api-url",
+        "https://YOUR-STACK.palantirfoundry.com"
+      ]
+    }
+  }
+}
 ```
 
-## Fetching Documentation
+## Development (this repo)
+
+### Setup
+
+```bash
+mise run setup
+```
+
+### Common tasks
+
+- Build: `mise run build`
+- Test: `mise run test`
+- Lint: `mise run lint`
+- Typecheck: `mise run typecheck`
+- Format: `mise run format`
+
+### Smoke test the built artifact
+
+```bash
+mise run smoke
+```
+
+### Fetch docs parquet (local dev)
 
 Fetch all Palantir docs into `data/docs.parquet` (~2 minutes, ~17MB file):
 
@@ -141,9 +236,7 @@ Fetch all Palantir docs into `data/docs.parquet` (~2 minutes, ~17MB file):
 bun run src/docs/fetch-cli.ts
 ```
 
-## Querying the Data
-
-### Schema
+### Parquet schema (local dev)
 
 The Parquet file contains a single row group with the following columns:
 
@@ -156,7 +249,7 @@ The Parquet file contains a single row group with the following columns:
 | `meta`       | string  | JSON-encoded metadata               |
 | `fetched_at` | string  | ISO 8601 timestamp of when fetched  |
 
-### Bun
+Example (Bun):
 
 ```typescript
 import { parquetReadObjects } from 'hyparquet';
@@ -166,80 +259,6 @@ const file = await Bun.file('data/docs.parquet').arrayBuffer();
 // List all pages (url + title only)
 const pages = await parquetReadObjects({ file, columns: ['url', 'title'] });
 console.log(`${pages.length} pages`);
-
-// Search by title
-const matches = pages.filter((p) => p.title.includes('Pipeline'));
-console.log(matches.slice(0, 10));
-
-// Get a specific page's content by row index
-const urlToRow = new Map(pages.map((p, i) => [p.url, i]));
-const rowIndex = urlToRow.get('/foundry/ontology/overview/');
-if (rowIndex !== undefined) {
-  const [page] = await parquetReadObjects({
-    file,
-    rowStart: rowIndex,
-    rowEnd: rowIndex + 1,
-  });
-  console.log(page.content);
-}
-```
-
-## OpenCode Tools
-
-When installed as an OpenCode plugin, exposes:
-
-- **`get_doc_page`** - Retrieve a specific doc page by URL
-- **`list_all_docs`** - List all available documentation pages
-- **`/refresh-docs`** - Command to re-fetch all documentation
-- **`/setup-palantir-mcp`** - Command to bootstrap MCP config + tool gating
-- **`/rescan-palantir-mcp-tools`** - Command to re-scan `palantir-mcp` tools and add missing toggles
-- **`foundry-librarian`** - Foundry exploration agent (sub-agent)
-- **`foundry`** - Foundry execution agent (sub-agent)
-
-### Installing in OpenCode (this repo only)
-
-For local development against `dist/`, you can point the wrapper at the built artifact:
-
-```bash
-mkdir -p .opencode/plugins
-
-cat > .opencode/plugins/opencode-palantir.js <<'EOF'
-import plugin from '../../dist/index.js';
-
-export default plugin;
-EOF
-```
-
-## Development
-
-Build the plugin:
-
-```bash
-mise run build
-```
-
-Run tests:
-
-```bash
-mise run test
-```
-
-Smoke test the built artifact (build + verify tools load from `dist/index.js`):
-
-```bash
-mise run smoke
-```
-
-Lint code:
-
-```bash
-mise run lint
-```
-
-Format with Prettier:
-
-```bash
-mise run format
 ```
 
 ## Release notes

--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ EOF
 
 Then create a tiny wrapper file in `.opencode/plugins/`:
 
-Create a tiny wrapper file in `.opencode/plugins/`:
-
 ```bash
 mkdir -p .opencode/plugins
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This plugin never writes secrets to disk. In `opencode.jsonc`, the token is alwa
 
 - `FOUNDRY_URL`
   - Foundry base URL (used for auto-bootstrap and can be used as a default for `/setup-palantir-mcp`)
-  - Example: `https://YOUR-STACK.usw-3.palantirfoundry.com`
+  - Example: `https://YOUR-STACK.palantirfoundry.com`
 - `FOUNDRY_TOKEN`
   - Foundry token used by `palantir-mcp` for tool discovery
   - Must be exported (not just set in a shell)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![npm](https://img.shields.io/npm/v/@openontology/opencode-palantir?logo=npm&label=npm)](https://www.npmjs.com/package/@openontology/opencode-palantir)
 [![downloads](https://img.shields.io/npm/dm/@openontology/opencode-palantir?logo=npm&label=downloads)](https://www.npmjs.com/package/@openontology/opencode-palantir)
-![CI](https://github.com/anand-testcompare/opencode-palantir/actions/workflows/pr.yml/badge.svg)
+![CI](https://img.shields.io/github/actions/workflow/status/anand-testcompare/opencode-palantir/pr.yml?branch=main&label=CI&logo=github)
 ![bun](https://img.shields.io/badge/bun-1.3.2-000000?logo=bun&logoColor=white)
-![@opencode-ai/plugin](https://img.shields.io/github/package-json/dependency-version/anand-testcompare/opencode-palantir/dev/%40opencode-ai%2Fplugin?label=opencode%20plugin%20api)
+![@opencode-ai/plugin](https://img.shields.io/github/package-json/dependency-version/anand-testcompare/opencode-palantir/dev/%40opencode-ai%2Fplugin?label=opencode%20plugin%20api&logo=npm)
 ![palantir-mcp](https://img.shields.io/npm/v/palantir-mcp?logo=npm&label=palantir-mcp)
-![hyparquet](https://img.shields.io/github/package-json/dependency-version/anand-testcompare/opencode-palantir/hyparquet?label=hyparquet)
+![hyparquet](https://img.shields.io/github/package-json/dependency-version/anand-testcompare/opencode-palantir/hyparquet?label=hyparquet&logo=npm)
 
 OpenCode plugin that provides:
 

--- a/README.md
+++ b/README.md
@@ -104,9 +104,8 @@ This plugin never writes secrets to disk. In `opencode.jsonc`, the token is alwa
 
 ### Recommended setup (zsh, macOS/Linux)
 
-Keep secrets in a separate file and source it from your shell init.
-
-Create `~/.config/opencode/secrets.zsh`:
+Use your existing shell secrets file. For example, if you already source `~/.shell_secrets` from
+`~/.zshrc`, add:
 
 ```zsh
 export FOUNDRY_URL='https://YOUR-STACK.palantirfoundry.com'
@@ -116,14 +115,14 @@ export FOUNDRY_TOKEN='YOUR_TOKEN'
 Lock it down:
 
 ```bash
-chmod 600 ~/.config/opencode/secrets.zsh
+chmod 600 ~/.shell_secrets
 ```
 
-Source it from `~/.zshrc`:
+Ensure `~/.zshrc` sources it:
 
 ```zsh
-if [ -f "$HOME/.config/opencode/secrets.zsh" ]; then
-  source "$HOME/.config/opencode/secrets.zsh"
+if [ -f "$HOME/.shell_secrets" ]; then
+  source "$HOME/.shell_secrets"
 fi
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,17 @@ Add the plugin to your OpenCode config:
 ```jsonc
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@openontology/opencode-palantir@^0.1.1"]
+  "plugin": ["@openontology/opencode-palantir@^0.1.4"]
 }
 ```
 
 Restart OpenCode.
+
+After enabling the plugin, OpenCode will automatically register:
+
+- Tools: `get_doc_page`, `list_all_docs`
+- Commands: `/refresh-docs`, `/setup-palantir-mcp`, `/rescan-palantir-mcp-tools`
+- Agents: `foundry-librarian`, `foundry`
 
 ### 2) (Optional) Install per-project
 
@@ -35,7 +41,7 @@ mkdir -p .opencode
 cat > .opencode/package.json <<'EOF'
 {
   "dependencies": {
-    "@openontology/opencode-palantir": "^0.1.1"
+    "@openontology/opencode-palantir": "^0.1.4"
   }
 }
 EOF
@@ -91,7 +97,22 @@ If `data/docs.parquet` is missing, both tools will instruct you to run `/refresh
 
 ## Foundry MCP setup helpers
 
-This plugin also provides two OpenCode commands to set up `palantir-mcp` with project-scoped tool
+This plugin registers Foundry helper commands and agents automatically at startup (config-driven).
+
+### Auto-bootstrap (no command required)
+
+If you set both `FOUNDRY_TOKEN` and `FOUNDRY_URL` in your environment, the plugin will
+automatically and idempotently patch repo-root `opencode.jsonc` to initialize:
+
+- `mcp.palantir-mcp` local server config
+- global tool deny: `tools.palantir-mcp_* = false`
+- per-agent `palantir-mcp_*` allow/deny toggles under `foundry-librarian` and `foundry`
+
+Secrets are never written: `FOUNDRY_TOKEN` is referenced as `{env:FOUNDRY_TOKEN}`.
+
+### Guided setup and maintenance
+
+You can also use the commands below to set up and maintain `palantir-mcp` with project-scoped tool
 gating and Foundry sub-agents:
 
 - **`/setup-palantir-mcp <foundry_api_url>`**
@@ -171,7 +192,11 @@ When installed as an OpenCode plugin, exposes:
 
 - **`get_doc_page`** - Retrieve a specific doc page by URL
 - **`list_all_docs`** - List all available documentation pages
-- **`/refresh-docs`** - Command hook to re-fetch all documentation
+- **`/refresh-docs`** - Command to re-fetch all documentation
+- **`/setup-palantir-mcp`** - Command to bootstrap MCP config + tool gating
+- **`/rescan-palantir-mcp-tools`** - Command to re-scan `palantir-mcp` tools and add missing toggles
+- **`foundry-librarian`** - Foundry exploration agent (sub-agent)
+- **`foundry`** - Foundry execution agent (sub-agent)
 
 ### Installing in OpenCode (this repo only)
 

--- a/src/__tests__/autoBootstrap.test.ts
+++ b/src/__tests__/autoBootstrap.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import * as mcpClient from '../palantir-mcp/mcp-client.ts';
+import { autoBootstrapPalantirMcpIfConfigured } from '../palantir-mcp/commands.ts';
+
+type McpServerConfig = {
+  type?: string;
+  command?: string[];
+  environment?: Record<string, unknown>;
+};
+
+type AgentConfig = {
+  tools?: Record<string, unknown>;
+};
+
+type OpencodeConfig = {
+  tools?: Record<string, unknown>;
+  mcp?: Record<string, McpServerConfig>;
+  agent?: Record<string, AgentConfig>;
+};
+
+describe('autoBootstrapPalantirMcpIfConfigured', () => {
+  let tmpDir: string;
+  let priorToken: string | undefined;
+  let priorUrl: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-auto-bootstrap-test-'));
+    priorToken = process.env.FOUNDRY_TOKEN;
+    priorUrl = process.env.FOUNDRY_URL;
+    delete process.env.FOUNDRY_TOKEN;
+    delete process.env.FOUNDRY_URL;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    if (priorToken === undefined) delete process.env.FOUNDRY_TOKEN;
+    else process.env.FOUNDRY_TOKEN = priorToken;
+    if (priorUrl === undefined) delete process.env.FOUNDRY_URL;
+    else process.env.FOUNDRY_URL = priorUrl;
+  });
+
+  it('does nothing when env is missing', async () => {
+    await autoBootstrapPalantirMcpIfConfigured(tmpDir);
+    expect(fs.existsSync(path.join(tmpDir, 'opencode.jsonc'))).toBe(false);
+  });
+
+  it('writes schema-valid config and never persists FOUNDRY_TOKEN', async () => {
+    process.env.FOUNDRY_TOKEN = 'SENTINEL_SECRET';
+    process.env.FOUNDRY_URL = 'https://example.palantirfoundry.com';
+
+    vi.spyOn(mcpClient, 'listPalantirMcpTools').mockResolvedValue([
+      'list_datasets',
+      'get_dataset',
+      'create_thing',
+    ]);
+
+    await autoBootstrapPalantirMcpIfConfigured(tmpDir);
+
+    const cfgPath: string = path.join(tmpDir, 'opencode.jsonc');
+    expect(fs.existsSync(cfgPath)).toBe(true);
+
+    const text: string = fs.readFileSync(cfgPath, 'utf8');
+    expect(text).not.toContain('SENTINEL_SECRET');
+    expect(text).toContain('{env:FOUNDRY_TOKEN}');
+
+    const cfg = JSON.parse(text) as OpencodeConfig;
+
+    expect(cfg.mcp?.['palantir-mcp']?.type).toBe('local');
+    expect(cfg.mcp?.['palantir-mcp']?.command).toContain('--foundry-api-url');
+    expect(cfg.mcp?.['palantir-mcp']?.command).toContain('https://example.palantirfoundry.com');
+
+    expect(cfg.tools?.['palantir-mcp_*']).toBe(false);
+
+    expect(cfg.agent?.['foundry-librarian']).toBeTruthy();
+    expect(cfg.agent?.foundry).toBeTruthy();
+
+    expect(cfg.agent?.['foundry-librarian']?.tools?.['palantir-mcp_list_datasets']).toBe(true);
+    expect(cfg.agent?.['foundry-librarian']?.tools?.['palantir-mcp_get_dataset']).toBe(true);
+    expect(cfg.agent?.['foundry-librarian']?.tools?.['palantir-mcp_create_thing']).toBe(false);
+  });
+
+  it('is idempotent for repeated runs', async () => {
+    process.env.FOUNDRY_TOKEN = 'TEST_TOKEN';
+    process.env.FOUNDRY_URL = 'https://example.palantirfoundry.com';
+
+    vi.spyOn(mcpClient, 'listPalantirMcpTools').mockResolvedValue(['list_datasets', 'get_dataset']);
+
+    await autoBootstrapPalantirMcpIfConfigured(tmpDir);
+    const first: string = fs.readFileSync(path.join(tmpDir, 'opencode.jsonc'), 'utf8');
+
+    await autoBootstrapPalantirMcpIfConfigured(tmpDir);
+    const second: string = fs.readFileSync(path.join(tmpDir, 'opencode.jsonc'), 'utf8');
+
+    expect(second).toBe(first);
+  });
+
+  it('skips tool discovery when config is already complete', async () => {
+    process.env.FOUNDRY_TOKEN = 'TEST_TOKEN';
+    process.env.FOUNDRY_URL = 'https://example.palantirfoundry.com';
+
+    const cfgPath: string = path.join(tmpDir, 'opencode.jsonc');
+    const existing: OpencodeConfig = {
+      tools: { 'palantir-mcp_*': false },
+      mcp: {
+        'palantir-mcp': {
+          type: 'local',
+          command: [
+            'npx',
+            '-y',
+            'palantir-mcp',
+            '--foundry-api-url',
+            'https://example.palantirfoundry.com',
+          ],
+          environment: { FOUNDRY_TOKEN: '{env:FOUNDRY_TOKEN}' },
+        },
+      },
+      agent: {
+        'foundry-librarian': { tools: { 'palantir-mcp_list_datasets': true } },
+        foundry: { tools: { 'palantir-mcp_list_datasets': true } },
+      },
+    };
+    fs.writeFileSync(cfgPath, JSON.stringify(existing, null, 2));
+
+    const spy = vi.spyOn(mcpClient, 'listPalantirMcpTools');
+    await autoBootstrapPalantirMcpIfConfigured(tmpDir);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/configHook.test.ts
+++ b/src/__tests__/configHook.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { Config } from '@opencode-ai/sdk';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const plugin = (await import('../index.ts')).default as any;
+
+describe('plugin config hook', () => {
+  let tmpDir: string;
+  let priorToken: string | undefined;
+  let priorUrl: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-config-test-'));
+    priorToken = process.env.FOUNDRY_TOKEN;
+    priorUrl = process.env.FOUNDRY_URL;
+    delete process.env.FOUNDRY_TOKEN;
+    delete process.env.FOUNDRY_URL;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (priorToken === undefined) delete process.env.FOUNDRY_TOKEN;
+    else process.env.FOUNDRY_TOKEN = priorToken;
+    if (priorUrl === undefined) delete process.env.FOUNDRY_URL;
+    else process.env.FOUNDRY_URL = priorUrl;
+  });
+
+  it('injects commands and agents', async () => {
+    const hooks = await plugin({ worktree: tmpDir });
+    expect(typeof hooks.config).toBe('function');
+
+    const cfg: Config = {};
+    await hooks.config(cfg);
+
+    expect(cfg.command?.['refresh-docs']?.template).toBeTruthy();
+    expect(cfg.command?.['setup-palantir-mcp']?.template).toBeTruthy();
+    expect(cfg.command?.['rescan-palantir-mcp-tools']?.template).toBeTruthy();
+
+    expect(cfg.agent?.['foundry-librarian']).toBeTruthy();
+    expect(cfg.agent?.foundry).toBeTruthy();
+  });
+
+  it('does not overwrite existing definitions', async () => {
+    const hooks = await plugin({ worktree: tmpDir });
+    expect(typeof hooks.config).toBe('function');
+
+    const cfg: Config = {
+      command: {
+        'refresh-docs': {
+          template: 'CUSTOM_TEMPLATE',
+          description: 'CUSTOM_DESCRIPTION',
+        },
+      },
+      agent: {
+        foundry: {
+          prompt: 'CUSTOM_PROMPT',
+          tools: {
+            get_doc_page: true,
+          },
+        },
+      },
+    };
+
+    await hooks.config(cfg);
+
+    expect(cfg.command?.['refresh-docs']?.template).toBe('CUSTOM_TEMPLATE');
+    expect(cfg.command?.['refresh-docs']?.description).toBe('CUSTOM_DESCRIPTION');
+
+    expect(cfg.agent?.foundry?.prompt).toBe('CUSTOM_PROMPT');
+    expect(cfg.agent?.foundry?.tools?.get_doc_page).toBe(true);
+    // Additive defaults are allowed.
+    expect(cfg.agent?.foundry?.tools?.list_all_docs).toBe(false);
+  });
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -186,7 +186,7 @@ describe('Plugin', () => {
     expect(result).not.toContain('/apollo/');
     expect(result).not.toContain('/gotham/');
 
-    const lineCount = result.split('\n').filter((l) => l.startsWith('- ')).length;
+    const lineCount = (result as string).split('\n').filter((l) => l.startsWith('- ')).length;
     expect(lineCount).toBeLessThanOrEqual(50);
   });
 

--- a/src/__tests__/palantirMcpSetup.test.ts
+++ b/src/__tests__/palantirMcpSetup.test.ts
@@ -47,11 +47,14 @@ const plugin = (await import('../index.ts')).default as unknown as MinimalPlugin
 describe('/setup-palantir-mcp', () => {
   let tmpDir: string;
   let priorToken: string | undefined;
+  let priorUrl: string | undefined;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-setup-test-'));
     priorToken = process.env.FOUNDRY_TOKEN;
+    priorUrl = process.env.FOUNDRY_URL;
     process.env.FOUNDRY_TOKEN = 'TEST_TOKEN';
+    delete process.env.FOUNDRY_URL;
   });
 
   afterEach(() => {
@@ -59,6 +62,8 @@ describe('/setup-palantir-mcp', () => {
     vi.restoreAllMocks();
     if (priorToken === undefined) delete process.env.FOUNDRY_TOKEN;
     else process.env.FOUNDRY_TOKEN = priorToken;
+    if (priorUrl === undefined) delete process.env.FOUNDRY_URL;
+    else process.env.FOUNDRY_URL = priorUrl;
   });
 
   async function runSetup(args: string): Promise<{ text: string }> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,8 +68,7 @@ const plugin: Plugin = async (input) => {
       agent.mode = 'subagent';
     }
 
-    const agentRecord = agent as unknown as Record<string, unknown>;
-    if (typeof agentRecord.hidden !== 'boolean') agentRecord.hidden = false;
+    if (typeof agent['hidden'] !== 'boolean') agent['hidden'] = false;
 
     if (typeof agent.description !== 'string') agent.description = defaultDescription;
 

--- a/src/palantir-mcp/commands.ts
+++ b/src/palantir-mcp/commands.ts
@@ -160,8 +160,11 @@ export async function autoBootstrapPalantirMcpIfConfigured(worktree: string): Pr
     if (readLegacy.ok) {
       await renameLegacyToBak(worktree);
     }
-  } catch {
+  } catch (err) {
     // Best-effort; never block startup on bootstrap failures.
+    // Intentionally no logging here (no-console; avoid polluting TUI). Use /setup-palantir-mcp
+    // for explicit, user-visible error output.
+    void err;
     return;
   }
 }

--- a/src/palantir-mcp/commands.ts
+++ b/src/palantir-mcp/commands.ts
@@ -27,6 +27,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
+function stableSortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableSortJson);
+  if (!isRecord(value)) return value;
+
+  const out: Record<string, unknown> = {};
+  for (const k of Object.keys(value).sort((a, b) => a.localeCompare(b))) {
+    out[k] = stableSortJson(value[k]);
+  }
+  return out;
+}
+
+function stableJsonStringify(value: unknown): string {
+  return JSON.stringify(stableSortJson(value));
+}
+
 function formatWarnings(warnings: string[]): string {
   if (warnings.length === 0) return '';
   return `\n\nWarnings:\n${warnings.map((w) => `- ${w}`).join('\n')}`;
@@ -62,14 +77,109 @@ async function resolveProfile(worktree: string): Promise<{
   }
 }
 
+function hasPalantirToolToggles(
+  data: Record<string, unknown>,
+  agentName: 'foundry-librarian' | 'foundry'
+): boolean {
+  const agents: unknown = data['agent'];
+  if (!isRecord(agents)) return false;
+  const agent: unknown = agents[agentName];
+  if (!isRecord(agent)) return false;
+  const tools: unknown = agent['tools'];
+  if (!isRecord(tools)) return false;
+  return Object.keys(tools).some((k) => k.startsWith('palantir-mcp_'));
+}
+
+function isAutoBootstrapAlreadyComplete(data: Record<string, unknown>): boolean {
+  const foundryUrl: string | null = extractFoundryApiUrlFromMcpConfig(data);
+
+  const toolsRoot: unknown = data['tools'];
+  const hasGlobalDeny: boolean = isRecord(toolsRoot) && toolsRoot['palantir-mcp_*'] === false;
+
+  const hasAgentToggles: boolean =
+    hasPalantirToolToggles(data, 'foundry-librarian') && hasPalantirToolToggles(data, 'foundry');
+
+  return !!foundryUrl && hasGlobalDeny && hasAgentToggles;
+}
+
+export async function autoBootstrapPalantirMcpIfConfigured(worktree: string): Promise<void> {
+  try {
+    const tokenRaw: string | undefined = process.env.FOUNDRY_TOKEN;
+    const urlRaw: string | undefined = process.env.FOUNDRY_URL;
+    if (!tokenRaw || tokenRaw.trim().length === 0) return;
+    if (!urlRaw || urlRaw.trim().length === 0) return;
+
+    const normalized = normalizeFoundryBaseUrl(urlRaw);
+    if ('error' in normalized) return;
+
+    const readJsonc = await readOpencodeJsonc(worktree);
+    if (!readJsonc.ok && !('missing' in readJsonc)) return;
+
+    const readLegacy = await readLegacyOpencodeJson(worktree);
+    if (!readLegacy.ok && !('missing' in readLegacy)) return;
+
+    const baseJsoncData: unknown = readJsonc.ok ? readJsonc.data : {};
+    const base: Record<string, unknown> = isRecord(baseJsoncData) ? baseJsoncData : {};
+    const merged: Record<string, unknown> = readLegacy.ok
+      ? mergeLegacyIntoJsonc(readLegacy.data, base)
+      : { ...base };
+
+    if (isAutoBootstrapAlreadyComplete(merged)) return;
+
+    const existingMcpUrlRaw: string | null = extractFoundryApiUrlFromMcpConfig(merged);
+    const existingMcpUrlNorm = existingMcpUrlRaw
+      ? normalizeFoundryBaseUrl(existingMcpUrlRaw)
+      : null;
+
+    const { profile } = await resolveProfile(worktree);
+    const discoveryUrl: string =
+      existingMcpUrlNorm && 'url' in existingMcpUrlNorm ? existingMcpUrlNorm.url : normalized.url;
+
+    const toolNames: string[] = await listPalantirMcpTools(discoveryUrl);
+    if (toolNames.length === 0) return;
+
+    const allowlist = computeAllowedTools(profile, toolNames);
+    const patch = patchConfigForSetup(merged, {
+      foundryApiUrl: normalized.url,
+      toolNames,
+      profile,
+      allowlist,
+    });
+
+    const jsoncMissing: boolean = !readJsonc.ok && 'missing' in readJsonc;
+    const needsMigration: boolean = jsoncMissing && readLegacy.ok;
+    const changed: boolean =
+      needsMigration || stableJsonStringify(merged) !== stableJsonStringify(patch.data);
+
+    if (!changed) return;
+
+    const outPath: string = path.join(worktree, OPENCODE_JSONC_FILENAME);
+    const text: string = stringifyJsonc(patch.data);
+    await writeFileAtomic(outPath, text);
+
+    if (readLegacy.ok) {
+      await renameLegacyToBak(worktree);
+    }
+  } catch {
+    // Best-effort; never block startup on bootstrap failures.
+    return;
+  }
+}
+
 export async function setupPalantirMcp(worktree: string, rawArgs: string): Promise<string> {
-  const urlArg: string = rawArgs.trim();
+  const urlFromArgs: string = rawArgs.trim();
+  const urlFromEnvRaw: string | undefined = process.env.FOUNDRY_URL;
+  const urlFromEnv: string = typeof urlFromEnvRaw === 'string' ? urlFromEnvRaw.trim() : '';
+  const urlArg: string = urlFromArgs || urlFromEnv;
   if (!urlArg) {
     return [
       '[ERROR] Missing Foundry base URL.',
       '',
       'Usage:',
       '  /setup-palantir-mcp <foundry_api_url>',
+      '',
+      'Or set:',
+      '  export FOUNDRY_URL=<foundry_api_url>',
       '',
       'Example:',
       '  /setup-palantir-mcp https://23dimethyl.usw-3.palantirfoundry.com',


### PR DESCRIPTION
Closes #15

## What
- Register Palantir commands + Foundry agents via plugin config hook (so they appear immediately after plugin install).
- If FOUNDRY_TOKEN + FOUNDRY_URL are set, auto-bootstrap palantir-mcp by patching repo-root opencode.jsonc (additive + idempotent; never writes secrets).

## Tests
- mise run lint
- mise run typecheck
- mise run test
- mise run build
- mise run pkgjsonlint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-shot auto-bootstrap when FOUNDRY_URL/FOUNDRY_TOKEN are present; plugin auto-registers tools, commands, and agents with per-tool toggles and idempotent updates.
  * setup-palantir-mcp accepts FOUNDRY_URL from environment as a fallback; rescan-palantir-mcp-tools and refreshed refresh-docs behavior.
  * Config hook applies sensible command and agent defaults at config-time.

* **Documentation**
  * README overhaul: OS support, Bun-based install flow, per-project install/auto-registration notes, env-based token/secret guidance, Parquet schema and examples.

* **Tests**
  * New tests covering auto-bootstrap idempotence, config-hook defaults, env handling, and skipping discovery when config exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->