### PR TITLE
fix: update GitHub account references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![npm](https://img.shields.io/npm/v/@openontology/opencode-palantir?logo=npm&label=npm)](https://www.npmjs.com/package/@openontology/opencode-palantir)
 [![downloads](https://img.shields.io/npm/dm/@openontology/opencode-palantir?logo=npm&label=downloads)](https://www.npmjs.com/package/@openontology/opencode-palantir)
-![CI](https://img.shields.io/github/actions/workflow/status/anand-testcompare/opencode-palantir/pr.yml?branch=main&label=CI&logo=github)
+![CI](https://img.shields.io/github/actions/workflow/status/anandpant/opencode-palantir/pr.yml?branch=main&label=CI&logo=github)
 ![bun](https://img.shields.io/badge/bun-1.3.13-000000?logo=bun&logoColor=white)
-![@opencode-ai/plugin](https://img.shields.io/github/package-json/dependency-version/anand-testcompare/opencode-palantir/dev/%40opencode-ai%2Fplugin?label=opencode%20plugin%20api&logo=npm)
+![@opencode-ai/plugin](https://img.shields.io/github/package-json/dependency-version/anandpant/opencode-palantir/dev/%40opencode-ai%2Fplugin?label=opencode%20plugin%20api&logo=npm)
 ![palantir-mcp](https://img.shields.io/npm/v/palantir-mcp?logo=npm&label=palantir-mcp)
-![hyparquet](https://img.shields.io/github/package-json/dependency-version/anand-testcompare/opencode-palantir/hyparquet?label=hyparquet&logo=npm)
+![hyparquet](https://img.shields.io/github/package-json/dependency-version/anandpant/opencode-palantir/hyparquet?label=hyparquet&logo=npm)
 
 OpenCode plugin that provides:
 
@@ -52,7 +52,7 @@ Avoid using `@latest` in config:
 To find the newest version and changelog:
 
 - NPM versions: https://www.npmjs.com/package/@openontology/opencode-palantir
-- GitHub releases: https://github.com/anand-testcompare/opencode-palantir/releases
+- GitHub releases: https://github.com/anandpant/opencode-palantir/releases
 - Repo changelog: `CHANGELOG.md`
 
 ### (Optional) Install per-project

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -61,6 +61,6 @@ GitHub does not automatically mirror npmjs.com packages into the GitHub "Package
 If you want versions to appear under GitHub Packages, you must publish an npm package to
 GitHub Packages (`npm.pkg.github.com`) as an additional registry.
 
-Note: GitHub Packages scopes are tied to the GitHub org/user (e.g. `@anand-testcompare/*`). If you
+Note: GitHub Packages scopes are tied to the GitHub org/user (e.g. `@anandpant/*`). If you
 want the GitHub package scope to match `@openontology/*`, the repo needs to live under a GitHub org
 named `openontology`.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/anand-testcompare/opencode-palantir.git"
+    "url": "git+https://github.com/anandpant/opencode-palantir.git"
   },
   "publishConfig": {
     "access": "public",

--- a/src/docs/snapshot.ts
+++ b/src/docs/snapshot.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 export const DEFAULT_DOCS_SNAPSHOT_URLS: string[] = [
-  'https://raw.githubusercontent.com/anand-testcompare/opencode-palantir/main/data/docs.parquet',
+  'https://raw.githubusercontent.com/anandpant/opencode-palantir/main/data/docs.parquet',
 ];
 
 const MIN_SNAPSHOT_BYTES = 64;


### PR DESCRIPTION
## Summary

Update package metadata, badges, release docs, and the runtime snapshot URL to the renamed `anandpant` account.

## Validation

- `bun install --frozen-lockfile`
- `bun test` (71 passed, 1 pre-existing smoke test skipped)